### PR TITLE
feature/updating Full & Simple profiles

### DIFF
--- a/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
+++ b/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
@@ -18,11 +18,13 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
         'uicolor' => 'default',
         'uicolor_user' => 'default',
         'toolbar' => '[
+    [\'Source\'],
     [\'PasteText\',\'PasteFromWord\'],
-    [\'Link\',\'Unlink\',\'Media\',\'MediaEmbed\',\'Table\',\'SpecialChar\',\'-\',\'HorizontalRule\',\'DrupalBreak\',\'-\',\'RemoveFormat\',\'Maximize\'],
+    [\'Media\',\'MediaEmbed\',\'Table\',\'SpecialChar\',\'HorizontalRule\',\'DrupalBreak\',\'-\',\'RemoveFormat\',\'Maximize\'],
     \'/\',
     [\'Undo\',\'Redo\'],
-    [\'Bold\',\'Italic\',\'Underline\',\'-\',\'NumberedList\',\'BulletedList\',\'-\',\'JustifyLeft\',\'JustifyCenter\',\'JustifyRight\',\'-\',\'Link\',\'Unlink\',\'-\',\'Media\',\'-\',\'Table\',\'-\',\'Format\',\'Styles\',\'-\',\'Source\']
+    [\'Bold\',\'Italic\',\'Underline\',\'-\',\'NumberedList\',\'BulletedList\',\'-\',\'JustifyLeft\',\'JustifyCenter\',\'JustifyRight\',\'-\',\'Link\',\'Unlink\'],
+    [\'Format\',\'Styles\']
 ]',
         'expand' => 't',
         'width' => '100%',
@@ -100,109 +102,6 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
       ),
       'input_formats' => array(
         'filtered_html' => 'Filtered HTML',
-      ),
-    ),
-    'CKEditor Global Profile' => array(
-      'name' => 'CKEditor Global Profile',
-      'settings' => array(
-        'ckeditor_path' => '%l/ckeditor',
-      ),
-      'input_formats' => array(),
-    ),
-    'Full' => array(
-      'name' => 'Full',
-      'settings' => array(
-        'ss' => 2,
-        'default' => 't',
-        'show_toggle' => 't',
-        'uicolor' => 'default',
-        'uicolor_user' => 'default',
-        'toolbar' => '[
-    [\'Format\',\'Bold\',\'Italic\',\'-\',\'NumberedList\',\'BulletedList\',\'-\',\'Link\',\'Unlink\',\'Image\']
-]',
-        'expand' => 't',
-        'width' => '100%',
-        'lang' => 'en',
-        'auto_lang' => 't',
-        'language_direction' => 'default',
-        'allowed_content' => 't',
-        'extraAllowedContent' => '',
-        'enter_mode' => 'p',
-        'shift_enter_mode' => 'br',
-        'font_format' => 'p;div;pre;address;h1;h2;h3;h4;h5;h6',
-        'custom_formatting' => 'f',
-        'formatting' => array(
-          'custom_formatting_options' => array(
-            'indent' => 'indent',
-            'breakBeforeOpen' => 'breakBeforeOpen',
-            'breakAfterOpen' => 'breakAfterOpen',
-            'breakAfterClose' => 'breakAfterClose',
-            'pre_indent' => 'pre_indent',
-            'breakBeforeClose' => 0,
-          ),
-        ),
-        'css_mode' => 'none',
-        'css_path' => '',
-        'css_style' => 'theme',
-        'styles_path' => '',
-        'filebrowser' => 'none',
-        'filebrowser_image' => '',
-        'filebrowser_flash' => '',
-        'UserFilesPath' => '%b%f/',
-        'UserFilesAbsolutePath' => '%d%b%f/',
-        'forcePasteAsPlainText' => 'f',
-        'html_entities' => 'f',
-        'scayt_autoStartup' => 'f',
-        'theme_config_js' => 'f',
-        'js_conf' => '',
-        'loadPlugins' => array(
-          'counter' => array(
-            'name' => 'counter',
-            'desc' => 'Plugin to count symbols, symbols without blanks and words',
-            'path' => '%plugin_dir%counter/',
-            'buttons' => FALSE,
-            'default' => 'f',
-          ),
-          'drupalbreaks' => array(
-            'name' => 'drupalbreaks',
-            'desc' => 'Plugin for inserting Drupal teaser and page breaks.',
-            'path' => '%plugin_dir%drupalbreaks/',
-            'buttons' => array(
-              'DrupalBreak' => array(
-                'label' => 'DrupalBreak',
-                'icon' => 'images/drupalbreak.png',
-              ),
-            ),
-            'default' => 't',
-          ),
-          'media' => array(
-            'name' => 'media',
-            'desc' => 'Plugin for inserting images from Drupal media module',
-            'path' => '%plugin_dir%media/',
-            'buttons' => array(
-              'Media' => array(
-                'label' => 'Media',
-                'icon' => 'images/icon.gif',
-              ),
-            ),
-            'default' => 'f',
-          ),
-          'mediaembed' => array(
-            'name' => 'mediaembed',
-            'desc' => 'Plugin for inserting Drupal embeded media',
-            'path' => '%plugin_dir%mediaembed/',
-            'buttons' => array(
-              'MediaEmbed' => array(
-                'label' => 'MediaEmbed',
-                'icon' => 'images/icon.png',
-              ),
-            ),
-            'default' => 'f',
-          ),
-        ),
-      ),
-      'input_formats' => array(
-        'full_html' => 'Full HTML',
       ),
     ),
     'CKEditor Global Profile' => array(
@@ -228,6 +127,8 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
         'lang' => 'en',
         'auto_lang' => 't',
         'language_direction' => 'default',
+        'allowed_content' => 't',
+        'extraAllowedContent' => '',
         'enter_mode' => 'p',
         'shift_enter_mode' => 'br',
         'font_format' => 'p;h2;h3;h4;h5;h6;pre',
@@ -295,9 +196,7 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
           ),
         ),
       ),
-      'input_formats' => array(
-        'filtered_html' => 'Filtered HTML',
-      ),
+      'input_formats' => array(),
     ),
   );
   return $data;

--- a/imagex_wysiwyg_profiles.info
+++ b/imagex_wysiwyg_profiles.info
@@ -1,4 +1,5 @@
 name = WYSIWYG and Text Formats
+description = Bundles settings for Ckeditor profiles.
 core = 7.x
 package = ImageX
 version = 7.x-1.0


### PR DESCRIPTION
Ready: (No)

Not ready because it removes code and I don't know if it's important, why it's doing that and how to prevent it.
## Changes
- updating default buttons on [Advanced](https://www.evernote.com/shard/s240/sh/be3f43c1-e0a5-4650-8246-e41563d4aeb8/c4ada59982c993daa8eba0237a6ef1e1), [Full](http://cl.ly/image/0c0G46110F0q) and [Simple](http://cl.ly/image/3A1A47001b0n)
- by default **ony enable Advanced** and assign to Filtered HTML
- removing duplicate buttons on advanced profile
