### PR TITLE
Feature: Add ability to not filter class and id properties.

### DIFF
--- a/imagex_wysiwyg_profiles.features.filter.inc
+++ b/imagex_wysiwyg_profiles.features.filter.inc
@@ -84,6 +84,7 @@ th',
             'Null_Cache.SerializerPath' => 1,
             'Cache.SerializerPermissions' => 493,
             'Core.AggressivelyFixLt' => 1,
+            'Core.AllowHostnameUnderscore' => 0,
             'Core.CollectErrors' => 0,
             'Core.ColorKeywords' => 'maroon:#800000
 red:#FF0000
@@ -126,7 +127,7 @@ style',
             'Null_Filter.ExtractStyleBlocks.TidyImpl' => 1,
             'Filter.ExtractStyleBlocks' => 0,
             'Filter.YouTube' => 0,
-            'HTML.Allowed' => '*[style]
+            'HTML.Allowed' => '*[style|class|id]
 a[href|target|title|name|id]
 em
 strong


### PR DESCRIPTION
## Ready State: Yes

Adds the ability for class and id attributes to be applied to elements that are run through the htmlpurifier filter.
## Requirements & Dependencies
- None
## Deployment Instructions
- Merge code.
- Revert `imagex_wysiwyg_profiles`: `drush fr imagex_wysiwyg_profiles`
- Clear caches with `drush cache-clear all`
## Usage/Test Instructions
- Verify setting took hold in htmlpurifier configuration on /admin/config/content/formats/filtered_html
