### PR TITLE
Feature: Update ckeditor profile to use the theme's css.

### DIFF
--- a/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
+++ b/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
@@ -47,7 +47,7 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
             'breakBeforeClose' => 0,
           ),
         ),
-        'css_mode' => 'none',
+        'css_mode' => 'theme',
         'css_path' => '',
         'css_style' => 'theme',
         'styles_path' => '',


### PR DESCRIPTION
## Ready State: Yes

Changes one settings so that the ckeditor profile uses the theme's css.
## Requirements & Dependencies
- None
## Deployment Instructions
- Merge code.
- Revert feature `imagex_wysiwyg_profiles`: `drush fr imagex_wysiwyg_profiles`
- Clear caches with `drush cache-clear all`
## Usage/Test Instructions
- Check the CSS section of the ckeditor profile to make sure it's set to theme css
