### PR TITLE
HOTFIX: added Media back to profile defaults. Media button was missing.

### DIFF
--- a/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
+++ b/imagex_wysiwyg_profiles.features.ckeditor_profile.inc
@@ -20,7 +20,7 @@ function imagex_wysiwyg_profiles_ckeditor_profile_defaults() {
         'toolbar' => '[
     [\'Source\'],
     [\'PasteText\',\'PasteFromWord\'],
-    [\'MediaEmbed\',\'Table\',\'SpecialChar\',\'HorizontalRule\',\'DrupalBreak\',\'-\',\'RemoveFormat\',\'Maximize\'],
+    [\'Media\',\'MediaEmbed\',\'Table\',\'SpecialChar\',\'HorizontalRule\',\'DrupalBreak\',\'-\',\'RemoveFormat\',\'Maximize\'],
     \'/\',
     [\'Undo\',\'Redo\'],
     [\'Bold\',\'Italic\',\'Underline\',\'-\',\'NumberedList\',\'BulletedList\',\'-\',\'JustifyLeft\',\'JustifyCenter\',\'JustifyRight\',\'-\',\'Link\',\'Unlink\'],


### PR DESCRIPTION
## Ready State: Yes

The media button was missing from the editor profiles, and wasn't showing on the available buttons, traced this to this commit:  https://github.com/imagex/imagex_wysiwyg_profiles/commit/2c696956a2e6d364d2f901fd5b23f5414a17e32c  which removed Media from configuration.

I updated the one line to add back Media.
## Requirements & Dependencies
-  media
- imagex_media
## Deployment Instructions
- Merge code.
## Usage/Test Instructions
- merge code, confirm that advanced configuration includes media button. 
