### PR TITLE
Bugs fix: Apply patches to integrate ckeditor with the latest media work.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -2,20 +2,26 @@ api = 2
 core = 7.x
 
 ; Contributed modules.
+projects[ckeditor][version] = "1.x-dev"
 projects[ckeditor][type] = "module"
 projects[ckeditor][subdir] = "contrib"
-projects[ckeditor][version] = "1.x-dev"
-projects[ckeditor][patch][] = "https://raw.github.com/imagex/imagex_patches/7.x/contrib/ckeditor/ckeditor_1504696_85.patch"
+projects[ckeditor][download][type] = "git"
+projects[ckeditor][download][revision] = "57245a9"
+projects[ckeditor][download][branch] = "7.x-1.x"
+; Integration with Media 2.x
+; http://drupal.org/node/1504696
+projects[ckeditor][patch][1504696] = "http://drupal.org/files/issues/ckeditor-accomodate-latest-media-changes-2159403-6.patch"
+; External plugin declarations are redundant.
+; http://drupal.org/comment/8284591#comment-8284591
+projects[ckeditor][patch][2158741] = "http://drupal.org/files/issues/ckeditor-remove-external-plugin-declarations-1-alt.patch"
+projects[ckeditor][patch][1649464] = "http://drupal.org/files/issues/ckeditor-hook_into_media_admin-1649464-8141819_0.patch"
 projects[htmlpurifier][type] = "module"
 projects[htmlpurifier][subdir] = "contrib"
 projects[htmlpurifier][version] = "1.0"
-projects[libraries][type] = "module"
-projects[libraries][subdir] = "contrib"
-projects[libraries][version] = "2.1"
 
 ; Libraries.
 libraries[ckeditor][download][type] = "file"
-libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.2.3/ckeditor_4.2.3_full.zip"
+libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.3.1/ckeditor_4.3.1_full.zip"
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[htmlpurifier][download][type] = "file"
 libraries[htmlpurifier][download][url] = "http://htmlpurifier.org/releases/htmlpurifier-4.6.0.zip"


### PR DESCRIPTION
## Ready State: Yes

Media recently refactored media integration support for ckeditor
module into the media_wysiwyg submodule. This includes patches to
make ckeditor work with media.

Also removes libraries project which is included in installkit.

Also moves ckeditor library version to 4.3.1.
### Patches from issues
- https://drupal.org/node/2159403
- https://drupal.org/node/1649464
- https://drupal.org/node/2158741
## Requirements & Dependencies
- PR for imagex_media improvements must be merged as well (to test, media will have to be rebuilt in addition to what's listed below) https://github.com/imagex/imagex_media/pull/10
## Deployment Instructions
- Merge code.
- Run build of ckeditor module and ckeditor library
- Clear caches with `drush cache-clear all`
- Clear browser's cache
## Usage/Test Instructions
- Go to wysiwyg editor and make sure media elements are tokenized and untokenized properly when the editor binds and unbinds by clicking "Switch to plain text editor" and then returning to the wysiwyg.
- Make sure media elements save properly and upon re-entering the edit form nothing has been stripped or removed.
- Test not only image media elements, but also document elements like pdf files using the default display mode to make sure the file icon is next to the link text and that neither are destroyed or broken on bind/unbind.
