### PR TITLE
Hotfix: Remove errant patch that doesn't apply cleanly.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -11,9 +11,6 @@ projects[ckeditor][download][branch] = "7.x-1.x"
 ; Integration with Media 2.x
 ; http://drupal.org/node/1504696
 projects[ckeditor][patch][1504696] = "http://drupal.org/files/issues/ckeditor-accomodate-latest-media-changes-2159403-6.patch"
-; External plugin declarations are redundant.
-; http://drupal.org/comment/8284591#comment-8284591
-; projects[ckeditor][patch][2158741] = "http://drupal.org/files/issues/ckeditor-remove-external-plugin-declarations-1-alt.patch"
 projects[ckeditor][patch][1649464] = "http://drupal.org/files/issues/ckeditor-hook_into_media_admin-1649464-8141819_0.patch"
 projects[htmlpurifier][type] = "module"
 projects[htmlpurifier][subdir] = "contrib"


### PR DESCRIPTION
## Ready State: Yes

Removes patch that wasn't strictly necessary and wasn't applying cleanly in combination with other patches.
## Requirements & Dependencies
- None
## Deployment Instructions
- Merge code.
- Rebuild `ckeditor` module
- Clear caches with `drush cache-clear all`
## Usage/Test Instructions
- Make sure builds cleanly
