### PR TITLE
Removed the libraries contrib project from codehighlighter's drupal-org.make

### DIFF
--- a/modules/imagex_wysiwyg_profiles_codehighlighter/drupal-org.make
+++ b/modules/imagex_wysiwyg_profiles_codehighlighter/drupal-org.make
@@ -5,9 +5,6 @@ core = 7.x
 projects[geshifilter][type] = "module"
 projects[geshifilter][subdir] = "contrib"
 projects[geshifilter][version] = "1.2"
-projects[libraries][type] = "module"
-projects[libraries][subdir] = "contrib"
-projects[libraries][version] = "2.1"
 
 ; Libraries.
 libraries[geshi][download][type] = "get"


### PR DESCRIPTION
## Ready State: Yes
- Removed the Libraries contrib module from within the CodeHighlighter's `drupal-org.make`.
## Deployment
- Merge code.
