### PR TITLE
Bugfix: Remove html5 video and source elements from full_html text format.

### DIFF
--- a/imagex_wysiwyg_profiles.features.filter.inc
+++ b/imagex_wysiwyg_profiles.features.filter.inc
@@ -390,9 +390,7 @@ thead
 tbody
 tfoot
 img[src|width|height|alt|title]
-iframe[src|class|width|height|frameborder|title|scrolling]
-video[width|height|class|controls]
-source[src|type]',
+iframe[src|class|width|height|frameborder|title|scrolling]',
             'Null_HTML.AllowedAttributes' => 1,
             'HTML.AllowedComments' => '',
             'HTML.AllowedCommentsRegexp' => '/^break$/',


### PR DESCRIPTION
## Ready State: Yes

Removes html5 video and source elements.
## Requirements & Dependencies
- None
## Deployment Instructions
- Merge code.
- Rebuild module.
- Revert feature.
- Clear caches with `drush cache-clear all`
## Usage/Test Instructions
- Make sure htmlpurifier errors are gone.
- Test and configure iframe video embeds to work.
